### PR TITLE
fix: adjust trackpad detection and wheel zoom scaling

### DIFF
--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -48,14 +48,14 @@ export function round(value: number, decimals: number) {
 }
 
 export function detectTrackpad(event: WheelEvent): boolean {
-  // deltaMode === 0 means the browser is reporting pixel-level deltas, which
-  // is the reliable cross-browser signal for trackpad (and touch) input.
-  // Mouse wheels report in line units (deltaMode === 1) or produce large
-  // discrete pixel values that don't use pixel mode.
-  // We avoid the fragile wheelDeltaY / deltaY * -3 ratio check because it
-  // breaks during high-velocity momentum scrolling on macOS, causing the
-  // canvas to jump 25x further than intended.
-  return event.deltaMode === 0;
+  // Line/page mode is always a mouse wheel.
+  if (event.deltaMode !== 0) return false;
+
+  // In pixel mode both inputs show up, so fall back to magnitude:
+  // trackpads send small deltas (usually under ~30), mouse wheels send
+  // chunks of ~100+ per notch. 50 sits comfortably between them.
+  const dominantDelta = Math.max(Math.abs(event.deltaX), Math.abs(event.deltaY));
+  return dominantDelta < 50;
 }
 export function normalizeWheelDelta(event: WheelEvent): { deltaX: number; deltaY: number } {
   let { deltaX, deltaY, deltaMode } = event;

--- a/core/src/zoompinch.ts
+++ b/core/src/zoompinch.ts
@@ -237,7 +237,11 @@ export class Zoompinch extends EventTarget {
 
     if (ctrlKey) {
       const zoomSpeed = isTrackpad ? 0.01 * this.zoomSpeedAppleTrackpad : 0.1 * this.zoomSpeed;
-      const scaleFactor = 1 + -deltaY * zoomSpeed;
+      // Cap the per-event multiplier so a single oversized wheel event
+      // cannot drive scaleFactor to 0 or negative — which would clamp newScale to
+      // minScale on the first tick and silently kill zoom.
+      const cappedDelta = clamp(-deltaY * zoomSpeed, -0.5, 0.5);
+      const scaleFactor = 1 + cappedDelta;
 
       let newScale = currScale * scaleFactor;
 


### PR DESCRIPTION
## Summary

On Chrome/Edge for Windows, ctrl+wheel zooms **in** but does nothing on **zoom-out**. The fix is in `core` so both the Vue and React wrappers pick it up.

Should be related to #1

## Root cause

Two things compounded:

1. **`detectTrackpad` misclassified Windows wheel.** It returned `true` whenever `deltaMode === 0` (pixel mode). Chromium on Windows reports mouse-wheel events in pixel mode with `deltaY = ±100` (or ±120) per notch, so a regular mouse was treated as a trackpad.

2. **The zoom math then broke for the zoom-out direction.** With `isTrackpad = true`, `handleWheel` skipped its `±100 → ±1` mouse normalization, leaving `deltaY = 100`. Combined with the trackpad `zoomSpeed = 0.01`.

Zoom-in had `scaleFactor = 2` and still worked, just over-aggressively.

## Changes

- **`core/src/helpers.ts` - `detectTrackpad`** Pixel mode alone isn't enough on Windows. Added a magnitude check: trackpads send small deltas (usually under ~30), mouse wheels send chunks of ~100+ per notch. A 50px threshold sits comfortably in between. Line/page mode remains an unconditional mouse signal. The previous comment about avoiding the legacy `wheelDeltaY / deltaY === -3` ratio still applies - momentum-scroll deltas stay small, so the magnitude check keeps them classified as trackpad.

- **`core/src/zoompinch.ts` - `handleWheel`** Defensive cap on the per-event zoom multiplier:

```ts
const cappedDelta = clamp(-deltaY * zoomSpeed, -0.5, 0.5);
const scaleFactor = 1 + cappedDelta;
```

## Test plan

- [x]  Windows + mouse wheel: ctrl+wheel zooms both in and out
- [x]  macOS trackpad: pinch / two-finger ctrl-scroll still zooms smoothly, no jumps during momentum
- [x]  macOS mouse wheel: still zooms
- [ ]  Windows trackpad (precision touchpad): still zooms
- [ ]  Pan is unchanged on all of the above

Need some help testing coz i don't have any windows/linux laptop.
